### PR TITLE
chore: migrate to Speakeasy workflows

### DIFF
--- a/.github/workflows/speakeasy_sdk_generation.yml
+++ b/.github/workflows/speakeasy_sdk_generation.yml
@@ -1,34 +1,26 @@
 name: Generate
-
 permissions:
-  checks: write
-  contents: write
-  pull-requests: write
-  statuses: write
-
-on:
-  workflow_dispatch:
-    inputs:
-      force:
-        description: "Force the generation of the SDKs"
-        type: boolean
-        default: false
-  schedule:
-    - cron: 0 0 * * *
-
+    checks: write
+    contents: write
+    pull-requests: write
+    statuses: write
+"on":
+    workflow_dispatch:
+        inputs:
+            force:
+                description: Force the generation of the SDKs
+                type: boolean
+                default: false
+    schedule:
+        - cron: 0 0 * * *
 jobs:
-  generate:
-    uses: speakeasy-api/sdk-generation-action/.github/workflows/sdk-generation.yaml@v14
-    with:
-      speakeasy_version: latest
-      create_release: true
-      openapi_docs: |
-        - https://raw.githubusercontent.com/inkeep/chat-api-openapi-schema/main/openapi.yaml
-      languages: |
-        - typescript
-      publish_typescript: true
-      force: ${{ github.event.inputs.force }}
-    secrets:
-      github_access_token: ${{ secrets.GITHUB_TOKEN }}
-      npm_token: ${{ secrets.NPM_TOKEN }}
-      speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}
+    generate:
+        uses: speakeasy-api/sdk-generation-action/.github/workflows/workflow-executor.yaml@v15
+        with:
+            force: ${{ github.event.inputs.force }}
+            mode: pr
+            speakeasy_version: latest
+        secrets:
+            github_access_token: ${{ secrets.GITHUB_TOKEN }}
+            npm_token: ${{ secrets.NPM_TOKEN }}
+            speakeasy_api_key: ${{ secrets.SPEAKEASY_API_KEY }}

--- a/.speakeasy/workflow.yaml
+++ b/.speakeasy/workflow.yaml
@@ -1,0 +1,12 @@
+workflowVersion: 1.0.0
+sources:
+    my-source:
+        inputs:
+            - location: https://raw.githubusercontent.com/inkeep/chat-api-openapi-schema/main/openapi.yaml
+targets:
+    ai-api-ts:
+        target: typescript
+        source: my-source
+        publish:
+            npm:
+                token: $NPM_TOKEN


### PR DESCRIPTION
This PR migrates this SDK to Speakeasy's new workflow file specification https://www.speakeasyapi.dev/docs/workflow-migration. `speakeasy migrate` was run to create this PR. 

Benefits: 
- Complete generation workflow is emulated locally now by checking out repo and running `speakeasy run`
- Opens up integrations with doc providers. 
![CleanShot 2024-04-15 at 11 15 07@2x](https://github.com/inkeep/ai-api-ts/assets/68016351/ab312834-8d48-4454-9c11-61c501496f76)

No changes to current code or future generations. 